### PR TITLE
Leader flag

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -31,5 +31,5 @@ if(typeof(String.prototype.trim) === "undefined")
 }
 
 function is_leader(user) {
-    user.role == "CommunityLeader"
+    return user.role == "CommunityLeader";
 }

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -29,3 +29,7 @@ if(typeof(String.prototype.trim) === "undefined")
     return String(this).replace(/^\s+|\s+$/g, '');
   };
 }
+
+function is_leader(user) {
+    user.role == "CommunityLeader"
+}

--- a/app/assets/javascripts/components/Dashboard.jsx
+++ b/app/assets/javascripts/components/Dashboard.jsx
@@ -15,7 +15,7 @@ class Dashboard extends React.Component {
 
     let actionButton = <span>No Leader Button for you!</span>;
 
-    if (user.is_leader) {
+    if (user.role == "CommunityLeader") {
       actionButton = <a href="#">Leader Button</a>;
     }
 

--- a/app/assets/javascripts/components/Dashboard.jsx
+++ b/app/assets/javascripts/components/Dashboard.jsx
@@ -15,7 +15,7 @@ class Dashboard extends React.Component {
 
     let actionButton = <span>No Leader Button for you!</span>;
 
-    if (user.role == "CommunityLeader") {
+    if (is_leader(user)) {
       actionButton = <a href="#">Leader Button</a>;
     }
 

--- a/app/assets/javascripts/components/Dashboard.jsx
+++ b/app/assets/javascripts/components/Dashboard.jsx
@@ -1,0 +1,26 @@
+class Dashboard extends React.Component {
+
+  constructor(props) {
+    super(props);
+    this.state = {
+    }
+  }
+
+  componentDidMount() {
+    // this.updateEvents();
+  }
+
+  render() {
+    const { user } = this.props;
+
+    let actionButton = <span>No Leader Button for you!</span>;
+
+    if (user.is_leader) {
+      actionButton = <a href="#">Leader Button</a>;
+    }
+
+    return (
+      <div>{actionButton}</div>
+    );
+  }
+}

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -21,6 +21,10 @@ class UsersController < ApplicationController
   def edit
   end
 
+  # GET /
+  def dashboard
+  end
+
   # POST /users
   # POST /users.json
   def create

--- a/app/views/users/dashboard.html.erb
+++ b/app/views/users/dashboard.html.erb
@@ -1,0 +1,4 @@
+
+<%= react_component('Dashboard', {user: current_user}) %>
+
+<%= link_to 'New User', new_user_path %>

--- a/app/views/users/dashboard.html.erb
+++ b/app/views/users/dashboard.html.erb
@@ -1,4 +1,2 @@
 
 <%= react_component('Dashboard', {user: current_user}) %>
-
-<%= link_to 'New User', new_user_path %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -8,7 +8,7 @@ Rails.application.routes.draw do
   resources :users
 
   authenticated :user do
-    root 'users#show', as: :authenticated_user_root
+    root 'users#dashboard', as: :authenticated_user_root
   end
 
   namespace :api, defaults: { format: :json } do

--- a/db/migrate/20181027201717_add_is_leader_to_users.rb
+++ b/db/migrate/20181027201717_add_is_leader_to_users.rb
@@ -1,0 +1,5 @@
+class AddIsLeaderToUsers < ActiveRecord::Migration[5.2]
+  def change
+    add_column :users, :is_leader, :boolean
+  end
+end

--- a/db/migrate/20181027222540_remove_is_leader_from_users.rb
+++ b/db/migrate/20181027222540_remove_is_leader_from_users.rb
@@ -1,0 +1,5 @@
+class RemoveIsLeaderFromUsers < ActiveRecord::Migration[5.2]
+  def change
+    remove_column :users, :is_leader
+  end
+end


### PR DESCRIPTION
### What does this PR do?
Uses the role enum `role` to distinguish community leaders and regular users so that we can display different components based on what type of user is logged in. Created a dashboard page with a sample of how it works.

Also implements a `is_leader(user)` function for javascript where you can pass in a user object and check if it is a community leader or not.

### Status
READY

### Description of Testing Done
1. Sign up and create a user account
2. Go to the dashboard page after logging in (which is the root dir)
3. Open rails console with `rails c`
4. Set the `role` to not `CommunityLeader` by running:
- `me = User.find(<user id>)`
- `me.role = :Admin`
- `me.save`
5. Refresh the page and make sure you see "No Leader Button for you!"
6. Set the `role` to `CommunityLeader` by running:
- `me = User.find(<user id>)`
- `me.role = :CommunityLeader`
- `me.save`
5. Refresh the page and make sure you see a link called "Leader Button"

CC: @michellejkwon
