### PR TITLE
Hides create project button if the logged in user is a volunteer

### DIFF
--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -2,6 +2,7 @@ class ProjectsController < ApplicationController
   before_action :set_project, only: [:show, :update, :destroy]
 
   def index
+    @user_type = current_user ? current_user.class.to_s : current_organization.class.to_s
     @skills = Skill.all
     @project_types = ProjectType.all
     @deliverable_types = DeliverableType.all

--- a/app/javascript/components/projects/ProjectsIndex.jsx
+++ b/app/javascript/components/projects/ProjectsIndex.jsx
@@ -209,12 +209,13 @@ class ProjectsIndex extends React.Component {
                         </div>
                     </div>
                     {
-                      user_type === 'User' ? '' :
+                      user_type === 'Organization' ?
                         <a
                         className="dib std-button pa2 fr"
                         href="/projects/new">
                         Create Project
                         </a>
+                        : ''
                     }
                     <div className="cf"></div>
                     <div className="w-100 h1 mt3">

--- a/app/javascript/components/projects/ProjectsIndex.jsx
+++ b/app/javascript/components/projects/ProjectsIndex.jsx
@@ -140,7 +140,7 @@ class ProjectsIndex extends React.Component {
     }
     axios.post("/api/projects/filter", payload).then(ret => {
       const { projects, message } = ret.data;
-      this.setState({ 
+      this.setState({
         projects: projects,
         loading: false
     });
@@ -170,6 +170,7 @@ class ProjectsIndex extends React.Component {
   };
 
   render() {
+    let { user_type} = this.props
     let { loading, projects, filter_by_user_skills } = this.state;
 
     var skill_filter_checkbox;
@@ -178,7 +179,7 @@ class ProjectsIndex extends React.Component {
             <div className="dib fr f5 mr4 bg-white disable-selection pt1">
                 Filter by My Skills: <input
                     type="checkbox"
-                    onChange={this.handleSkillCheck} 
+                    onChange={this.handleSkillCheck}
                     checked={filter_by_user_skills} />
             </div>);
     }
@@ -207,11 +208,14 @@ class ProjectsIndex extends React.Component {
                             </div>
                         </div>
                     </div>
-                    <a
+                    {
+                      user_type === 'User' ? '' :
+                        <a
                         className="dib std-button pa2 fr"
                         href="/projects/new">
                         Create Project
-                    </a>
+                        </a>
+                    }
                     <div className="cf"></div>
                     <div className="w-100 h1 mt3">
                         <div className="dib fl">

--- a/app/views/projects/index.html.erb
+++ b/app/views/projects/index.html.erb
@@ -1,4 +1,4 @@
 <% if user_signed_in? || organization_signed_in? %>
-    <%= react_component('projects/ProjectsIndex', {skills: @skills, project_types: @project_types, deliverable_types: @deliverable_types, user: current_user, user_type: current_user.class.to_s }) %>
+    <%= react_component('projects/ProjectsIndex', {skills: @skills, project_types: @project_types, deliverable_types: @deliverable_types, user: current_user, user_type: @user_type }) %>
 <% end %>
 

--- a/app/views/projects/index.html.erb
+++ b/app/views/projects/index.html.erb
@@ -1,4 +1,4 @@
 <% if user_signed_in? || organization_signed_in? %>
-    <%= react_component('projects/ProjectsIndex', {skills: @skills, project_types: @project_types, deliverable_types: @deliverable_types, user: current_user }) %>
+    <%= react_component('projects/ProjectsIndex', {skills: @skills, project_types: @project_types, deliverable_types: @deliverable_types, user: current_user, user_type: current_user.class.to_s }) %>
 <% end %>
 


### PR DESCRIPTION
### What does this PR do?
Hides the Create Project button if the logged in user is a volunteer

### Status
READY


### Description of Testing Done
Manual testing was done
-  Logged in as a volunteer to confirm the `Create Project` does not appear on a volunteer's page
- Logged in as an organization to confirm the `Create Project` button appears

### Screenshots
[insert image(s) here]
## Organization has `Create Project` Button Present
<img width="1440" alt="Screen Shot 2019-11-26 at 9 32 15 PM" src="https://user-images.githubusercontent.com/4732011/69696463-99d07080-1094-11ea-9c38-05e0936474ae.png">

## Volunteer has `Create Project` Button removed
<img width="1440" alt="Screen Shot 2019-11-26 at 9 31 48 PM" src="https://user-images.githubusercontent.com/4732011/69696507-bcfb2000-1094-11ea-8914-304ac186cf46.png">



CC: @ethanlee16 
