### PR TITLE
a11y changes: adds outline for fields and text area

### DIFF
--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -98,10 +98,6 @@ select {
   width: 100%;
 }
 
-input:focus {
-  outline: 3px solid  #000;
-}
-
 input.input {
   width: 100%;
   -webkit-box-sizing: border-box; /* Safari/Chrome, other WebKit */
@@ -224,7 +220,9 @@ input.input {
 }
 
 .essay-box:focus {
-  outline: 3px solid  #000;
+  outline-width: 2px;
+  outline-color: -webkit-focus-ring-color;
+  outline-style: auto;
 }
 
 .rt-yellow-bg {

--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -99,7 +99,7 @@ select {
 }
 
 input:focus {
-  outline: none;
+  outline: 3px solid  #000;
 }
 
 input.input {
@@ -221,6 +221,10 @@ input.input {
   outline: none;
   resize: none;
   overflow: auto;
+}
+
+.essay-box:focus {
+  outline: 3px solid  #000;
 }
 
 .rt-yellow-bg {


### PR DESCRIPTION
### What does this PR do?
Removes `outline: none` and adds an outline on focus to make forms/text-area boxes accessible

### Status
READY

### Screenshots
<img width="498" alt="Screen Shot 2019-11-27 at 11 29 56 PM" src="https://user-images.githubusercontent.com/4732011/69786232-d83a5e00-116e-11ea-9c7a-8298ff6b8dc1.png">
